### PR TITLE
Add ctrl+left and ctrl+right bindings

### DIFF
--- a/provisioning/roles/zsh/files/.zshrc
+++ b/provisioning/roles/zsh/files/.zshrc
@@ -37,6 +37,8 @@ bindkey '^?' backward-delete-char
 
 bindkey j accept-line
 bindkey g complete-word
+bindkey '^[[1;5C' forward-word
+bindkey '^[[1;5D' backward-word
 
 ###################
 ## Options Settings


### PR DESCRIPTION
Add ctrl+left and ctrl+right bindings in the default .zshrc so that navigate on the current command line becomes easier.