### PR TITLE
Replace # by double quotes for commented line

### DIFF
--- a/provisioning/roles/neovim/files/init.vim
+++ b/provisioning/roles/neovim/files/init.vim
@@ -67,8 +67,8 @@ nnoremap <silent> K :call LanguageClient_textDocument_hover()<CR>
 nnoremap <silent> gd :call LanguageClient_textDocument_definition()<CR>
 nnoremap <silent> <F2> :call LanguageClient_textDocument_rename()<CR>
 
-# So that we don't need to reach <ESC> key
-# or `:`
+" So that we don't need to reach <ESC> key
+" or `:`
 map <A-j> <ESC>
 map <A-f> :w<CR>
 map <A-d> :wq<CR>


### PR DESCRIPTION
Caused warnings when starting neovim.