### PR TITLE
upgrade to Ubuntu 20.04 LTS as a base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Re-use the phusion baseimage which runs an SSH server etc
-FROM phusion/baseimage:0.11
+FROM phusion/baseimage:focal-1.1.0
 
 # Some definitions
 ENV SUDOFILE /etc/sudoers


### PR DESCRIPTION
So some recent versions of some tools can be easily installed, like Wine.